### PR TITLE
Remove retries from ipfs resolver

### DIFF
--- a/implementations/ipfs/async-resolver/deployment.json
+++ b/implementations/ipfs/async-resolver/deployment.json
@@ -6,7 +6,7 @@
         "name": "ipfs_deploy",
         "id": "ipfs_deploy.ipfs_deploy",
         "input": "wrap://fs/./build",
-        "result": "wrap://ipfs/QmaoUNugyTkZ49n5s1p7Sb3eBFqR1PHJuLcptUgopqASoG"
+        "result": "wrap://ipfs/QmVQ8116QRSLSDVqU521VAYegJp4dcpzLza9K5LsGjfrvN"
       }
     ]
   }

--- a/implementations/ipfs/async-resolver/src/__tests__/utils/config.ts
+++ b/implementations/ipfs/async-resolver/src/__tests__/utils/config.ts
@@ -13,7 +13,6 @@ export const ipfsResolverUri: string = "wrap://package/ipfs-resolver";
 export function getClientConfig(
   provider: string,
   timeout?: number,
-  retries?: { tryResolveUri: number; getFile: number },
 ): PolywrapCoreClientConfig {
   const ipfsResolverPath = path.resolve(path.join(__dirname, "/../../../build"));
   const ipfsResolverFsUri = `wrap://fs/${ipfsResolverPath}`;
@@ -22,7 +21,7 @@ export function getClientConfig(
     .addEnvs([
         {
           uri: new Uri(ipfsResolverUri),
-          env: { provider, timeout, retries },
+          env: { provider, timeout },
         },
       ])
     .addRedirects([

--- a/implementations/ipfs/async-resolver/src/lib.rs
+++ b/implementations/ipfs/async-resolver/src/lib.rs
@@ -5,8 +5,9 @@ use util::*;
 use cid::Cid;
 
 pub fn try_resolve_uri(args: ArgsTryResolveUri, env: Option<Env>) -> Option<UriResolverMaybeUriOrManifest> {
-    let env = env.expect("Ipfs uri resolver requires a configured Env");
-
+    if env.is_none() {
+        panic!("Ipfs uri resolver requires a configured Env")
+    }
     if args.authority != "ipfs" {
         return None;
     }
@@ -17,34 +18,18 @@ pub fn try_resolve_uri(args: ArgsTryResolveUri, env: Option<Env>) -> Option<UriR
     }
 
     let path = format!("{}/wrap.info", &args.path);
-    let options: Options = get_options(&env, false);
-    let manifest: Option<Vec<u8>> = exec_with_options(&path, &options);
+    let manifest: Option<Vec<u8>> = get_file(ArgsGetFile { path }, env);
 
     return Some(UriResolverMaybeUriOrManifest { manifest, uri: None });
 }
 
 pub fn get_file(args: ArgsGetFile, env: Option<Env>) -> Option<Vec<u8>> {
     let env = env.expect("Ipfs uri resolver requires a configured Env");
-    let options: Options = get_options(&env, true);
-    exec_with_options(&args.path, &options)
-}
-
-fn exec_with_options(path: &str, options: &Options) -> Option<Vec<u8>> {
-    let synchronous = options.disable_parallel_requests || options.providers.len() == 1;
-    let mut attempts = options.retries + 1;
-    while attempts > 0 {
-        let result: Result<Vec<u8>, String>;
-        if synchronous {
-            result = exec_sequential(&options.providers, &path, options.timeout);
-        } else {
-            result = exec_parallel(&options.providers, &path, options.timeout);
-        };
-        if result.is_ok() {
-            return result.ok();
-        }
-        attempts = attempts - 1;
+    let options: Options = get_options(&env);
+    if options.disable_parallel_requests || options.providers.len() == 1 {
+        return exec_sequential(&options.providers, &args.path, options.timeout).ok();
     }
-    None
+    return exec_parallel(&options.providers, &args.path, options.timeout).ok();
 }
 
 fn is_cid(maybe_cid: &str) -> bool {

--- a/implementations/ipfs/async-resolver/src/schema.graphql
+++ b/implementations/ipfs/async-resolver/src/schema.graphql
@@ -6,20 +6,7 @@
 
 type Module implements UriResolver_Module {}
 
-"""
-Number of times to retry request on failure (excluding initial request)
-"""
-type Retries {
-  tryResolveUri: UInt32
-  getFile: UInt32
-}
-
 type Env {
-  """
-  Retry request on failure
-  """
-  retries: Retries
-
   """
   Response timeout for HTTP requests
   """

--- a/implementations/ipfs/async-resolver/src/util/options.rs
+++ b/implementations/ipfs/async-resolver/src/util/options.rs
@@ -1,27 +1,16 @@
-use crate::wrap::{Env, Retries};
+use crate::wrap::{Env};
 
 pub struct Options<'t> {
     pub disable_parallel_requests: bool,
     pub timeout: u32,
-    pub retries: u32,
     pub providers: Vec<&'t str>,
 }
 
-pub fn get_options<'t>(env: &'t Env, is_get_file: bool) -> Options<'t> {
+pub fn get_options<'t>(env: &'t Env) -> Options<'t> {
 
     let disable_parallel_requests = env.disable_parallel_requests.unwrap_or(false);
 
     let timeout = env.timeout.unwrap_or(5000);
-
-    let mut retries: u32 = 0;
-    if env.retries.is_some() {
-        let retry_options = env.retries.as_ref().unwrap();
-        if is_get_file {
-            retries = retry_options.get_file.unwrap_or(0);
-        } else {
-            retries = retry_options.try_resolve_uri.unwrap_or(0);
-        };
-    }
 
     let mut providers: Vec<&'t str> = Vec::new();
 
@@ -37,7 +26,6 @@ pub fn get_options<'t>(env: &'t Env, is_get_file: bool) -> Options<'t> {
     Options {
         disable_parallel_requests,
         timeout,
-        retries,
         providers,
     }
 }

--- a/implementations/ipfs/sync-resolver/deployment.json
+++ b/implementations/ipfs/sync-resolver/deployment.json
@@ -6,7 +6,7 @@
         "name": "ipfs_deploy",
         "id": "ipfs_deploy.ipfs_deploy",
         "input": "wrap://fs/./build",
-        "result": "wrap://ipfs/QmPWinvbC1cqXPxogjPrSbbVG1Vq2EvGEfRaf2ZbF2oNRA"
+        "result": "wrap://ipfs/Qme6PXwxQXnR8RvtcMoGYjrEQW2Ca9VFhmA9XiELfYCwDz"
       }
     ]
   }

--- a/implementations/ipfs/sync-resolver/src/lib.rs
+++ b/implementations/ipfs/sync-resolver/src/lib.rs
@@ -5,8 +5,9 @@ use util::*;
 use cid::Cid;
 
 pub fn try_resolve_uri(args: ArgsTryResolveUri, env: Option<Env>) -> Option<UriResolverMaybeUriOrManifest> {
-    let env = env.expect("Ipfs uri resolver requires a configured Env");
-
+    if env.is_none() {
+        panic!("Ipfs uri resolver requires a configured Env")
+    }
     if args.authority != "ipfs" {
         return None;
     }
@@ -17,28 +18,15 @@ pub fn try_resolve_uri(args: ArgsTryResolveUri, env: Option<Env>) -> Option<UriR
     }
 
     let path = format!("{}/wrap.info", &args.path);
-    let options: Options = get_options(&env, false);
-    let manifest: Option<Vec<u8>> = exec_with_options(&path, &options);
+    let manifest: Option<Vec<u8>> = get_file(ArgsGetFile { path }, env);
 
     return Some(UriResolverMaybeUriOrManifest { manifest, uri: None });
 }
 
 pub fn get_file(args: ArgsGetFile, env: Option<Env>) -> Option<Vec<u8>> {
     let env = env.expect("Ipfs uri resolver requires a configured Env");
-    let options: Options = get_options(&env, true);
-    exec_with_options(&args.path, &options)
-}
-
-fn exec_with_options(path: &str, options: &Options) -> Option<Vec<u8>> {
-    let mut attempts = options.retries + 1;
-    while attempts > 0 {
-        let result = exec_sequential(&options.providers, &path, options.timeout);
-        if result.is_ok() {
-            return result.ok();
-        }
-        attempts = attempts - 1;
-    }
-    None
+    let options: Options = get_options(&env);
+    exec_sequential(&options.providers, &args.path, options.timeout).ok()
 }
 
 fn is_cid(maybe_cid: &str) -> bool {

--- a/implementations/ipfs/sync-resolver/src/util/options.rs
+++ b/implementations/ipfs/sync-resolver/src/util/options.rs
@@ -2,23 +2,12 @@ use crate::wrap::Env;
 
 pub struct Options<'t> {
     pub timeout: u32,
-    pub retries: u32,
     pub providers: Vec<&'t str>,
 }
 
-pub fn get_options<'t>(env: &'t Env, is_get_file: bool) -> Options<'t> {
+pub fn get_options<'t>(env: &'t Env) -> Options<'t> {
 
     let timeout = env.timeout.unwrap_or(5000);
-
-    let mut retries: u32 = 0;
-    if env.retries.is_some() {
-        let retry_options = env.retries.as_ref().unwrap();
-        if is_get_file {
-            retries = retry_options.get_file.unwrap_or(0);
-        } else {
-            retries = retry_options.try_resolve_uri.unwrap_or(0);
-        };
-    }
 
     let mut providers: Vec<&'t str> = Vec::new();
 
@@ -33,7 +22,6 @@ pub fn get_options<'t>(env: &'t Env, is_get_file: bool) -> Options<'t> {
 
     Options {
         timeout,
-        retries,
         providers,
     }
 }


### PR DESCRIPTION
This PR removes the "retries" option from the ipfs resolver. For separation of concerns, that feature is moving to an `IUriResolver` implementation.

Depends on https://github.com/polywrap/toolchain/pull/1546