### PR TITLE
HTTP resolver with redirects

### DIFF
--- a/implementations/http/URI.txt
+++ b/implementations/http/URI.txt
@@ -1,1 +1,1 @@
-wrap://ipfs/QmT2KBTDtGMHRcNmAVbd7TkHRgoaCKpFWT4zR1Gf84Hr2X
+wrap://ipfs/QmansMm6hUBYs7D7EW1zA7BFBnDBGGgCM2jyVTWuDmMVNx

--- a/implementations/http/URI.txt
+++ b/implementations/http/URI.txt
@@ -1,1 +1,1 @@
-wrap://ipfs/QmaeTXFi7VuDPk33SPNoNe3Z3rxPgXtVv8yppu2vhvN517
+wrap://ipfs/QmT2KBTDtGMHRcNmAVbd7TkHRgoaCKpFWT4zR1Gf84Hr2X

--- a/implementations/http/deployment.json
+++ b/implementations/http/deployment.json
@@ -6,7 +6,7 @@
         "name": "ipfs_deploy",
         "id": "ipfs_deploy.ipfs_deploy",
         "input": "wrap://fs/./build",
-        "result": "wrap://ipfs/QmT2KBTDtGMHRcNmAVbd7TkHRgoaCKpFWT4zR1Gf84Hr2X"
+        "result": "wrap://ipfs/QmansMm6hUBYs7D7EW1zA7BFBnDBGGgCM2jyVTWuDmMVNx"
       }
     ]
   }

--- a/implementations/http/deployment.json
+++ b/implementations/http/deployment.json
@@ -6,7 +6,7 @@
         "name": "ipfs_deploy",
         "id": "ipfs_deploy.ipfs_deploy",
         "input": "wrap://fs/./build",
-        "result": "wrap://ipfs/QmaeTXFi7VuDPk33SPNoNe3Z3rxPgXtVv8yppu2vhvN517"
+        "result": "wrap://ipfs/QmT2KBTDtGMHRcNmAVbd7TkHRgoaCKpFWT4zR1Gf84Hr2X"
       }
     ]
   }

--- a/implementations/http/src/lib.rs
+++ b/implementations/http/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod wrap;
-use wrap::{*, imported::{ArgsGet}};
+use polywrap_wasm_rs::Map;
 use base64::decode;
+use wrap::{*, imported::ArgsGet};
 
 const MANIFEST_SEARCH_PATTERN: &str = "wrap.info";
+const URI_HEADER_KEY: &str = "x-wrap-uri";
 
 pub fn try_resolve_uri(args: ArgsTryResolveUri, _env: Option<Env>) -> Option<UriResolverMaybeUriOrManifest> {
     if args.authority != "http" && args.authority != "https" {
@@ -49,18 +51,37 @@ pub fn try_resolve_uri(args: ArgsTryResolveUri, _env: Option<Env>) -> Option<Uri
         Some(x) => x,
     };
 
+    let redirect_uri = get_redirect_uri_from_headers(&response.headers);
+
     match response.body {
-        None => return None,
-        Some(body) => match decode(body) {
-            Ok(body) => return Some(UriResolverMaybeUriOrManifest {
-                uri: None,
-                manifest: Some(body)
-            }),
-            Err(err) => {
-                panic!("Error during base64 decoding of body: {}", err.to_string());
+        None => None,
+        Some(body) => if body.len() == 0 {
+            Some(UriResolverMaybeUriOrManifest {
+                uri: redirect_uri,
+                manifest: None
+            })
+        } else {
+            match decode(body) {
+                Ok(body) => Some(UriResolverMaybeUriOrManifest {
+                    uri: redirect_uri,
+                    manifest: Some(body)
+                }),
+                Err(err) => {
+                    panic!("Error during base64 decoding of body: {}", err.to_string());
+                }
             }
         }
-    };
+    }
+}
+
+fn get_redirect_uri_from_headers(headers: &Option<Map<String, String>>) -> Option<String> {
+    if let Some(headers) = headers {
+        if let Some(uri) = headers.get(URI_HEADER_KEY) {
+            return Some(uri.clone())
+        }
+    }
+
+    None
 }
 
 pub fn get_file(args: ArgsGetFile, _env: Option<Env>) -> Option<Vec<u8>> {

--- a/implementations/http/src/lib.rs
+++ b/implementations/http/src/lib.rs
@@ -53,24 +53,27 @@ pub fn try_resolve_uri(args: ArgsTryResolveUri, _env: Option<Env>) -> Option<Uri
 
     let redirect_uri = get_redirect_uri_from_headers(&response.headers);
 
-    match response.body {
+    let manifest = match response.body {
         None => None,
         Some(body) => if body.len() == 0 {
-            Some(UriResolverMaybeUriOrManifest {
-                uri: redirect_uri,
-                manifest: None
-            })
+            None
         } else {
             match decode(body) {
-                Ok(body) => Some(UriResolverMaybeUriOrManifest {
-                    uri: redirect_uri,
-                    manifest: Some(body)
-                }),
+                Ok(body) => Some(body),
                 Err(err) => {
                     panic!("Error during base64 decoding of body: {}", err.to_string());
                 }
             }
         }
+    };
+
+    if redirect_uri.is_none() && manifest.is_none() {
+        None
+    } else {
+        Some(UriResolverMaybeUriOrManifest {
+            uri: redirect_uri,
+            manifest
+        })
     }
 }
 


### PR DESCRIPTION
HTTP gateways can now return a URI in addition to a wrap manifest.
The URI needs to be returned in the `x-wrap-uri` header.

This allows file gateways to function as is, while allowing polywrap specific gateways to either redirect to a URI or return the manifest themselves. 

If both the URI and manifest are returned, we should use the returned URI as the resolver in the FileReader of the newly created wrap package. This can/will be done in a follow up PR(s) in the client(s) (ExtendableUriResolver). This feature will allow even faster resolution since it eliminates the need to fetch the manifest from the redirected URI (As long as the HTTP gateway supports that).
