### PR TITLE
Fix: update github resolver deploymnet URI

### DIFF
--- a/implementations/github/URI.txt
+++ b/implementations/github/URI.txt
@@ -1,1 +1,1 @@
-wrap://ipfs/QmQcGmGnLDNFVbUtudfiW4M6FvPzqGBNSZqoqxqwXDfYeM
+wrap://ipfs/QmYPp2bQpRxR7WCoiAgWsWoiQzqxyFdqWxp1i65VW8wNv2

--- a/implementations/github/deployment.json
+++ b/implementations/github/deployment.json
@@ -6,7 +6,7 @@
         "name": "ipfs_deploy",
         "id": "ipfs_deploy.ipfs_deploy",
         "input": "wrap://fs/./build",
-        "result": "wrap://ipfs/QmQcGmGnLDNFVbUtudfiW4M6FvPzqGBNSZqoqxqwXDfYeM"
+        "result": "wrap://ipfs/QmYPp2bQpRxR7WCoiAgWsWoiQzqxyFdqWxp1i65VW8wNv2"
       }
     ]
   }


### PR DESCRIPTION
No changes were made to the github resolver itself. I simply ran `nvm use && yarn && yarn build && yarn test && yarn deploy` in the github resolver directory.