### PR TITLE
Added wrapscan header to CD and bumped wrapscan resolver version

### DIFF
--- a/.github/workflows/ens-contenthash-uri-resolver-cd.yaml
+++ b/.github/workflows/ens-contenthash-uri-resolver-cd.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Deploy
         run: yarn deploy
         working-directory: ./implementations/ens/contenthash
+        env:
+          POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD: ${{secrets.POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD}}
 
       - name: PR New URI
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/ens-ipfs-contenthash-uri-resolver-cd.yaml
+++ b/.github/workflows/ens-ipfs-contenthash-uri-resolver-cd.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Deploy
         run: yarn deploy
         working-directory: ./implementations/ens/ipfs-contenthash
+        env:
+          POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD: ${{secrets.POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD}}
 
       - name: PR New URI
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/ens-ocr-contenthash-uri-resolver-cd.yaml
+++ b/.github/workflows/ens-ocr-contenthash-uri-resolver-cd.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Deploy
         run: yarn deploy
         working-directory: ./implementations/ens/ocr-contenthash
+        env:
+          POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD: ${{secrets.POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD}}
 
       - name: PR New URI
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/ens-text-record-uri-resolver-cd.yaml
+++ b/.github/workflows/ens-text-record-uri-resolver-cd.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Deploy
         run: yarn deploy
         working-directory: ./implementations/ens/text-record
+        env:
+          POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD: ${{secrets.POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD}}
 
       - name: PR New URI
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/fs-uri-resolver-cd.yaml
+++ b/.github/workflows/fs-uri-resolver-cd.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Deploy
         run: yarn deploy
         working-directory: ./implementations/file-system
+        env:
+          POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD: ${{secrets.POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD}}
 
       - name: PR New URI
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/github-resolver-cd.yaml
+++ b/.github/workflows/github-resolver-cd.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Deploy
         run: yarn deploy
         working-directory: ./implementations/github
+        env:
+          POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD: ${{secrets.POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD}}
 
       - name: PR New URI
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/http-uri-resolver-cd.yaml
+++ b/.github/workflows/http-uri-resolver-cd.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Deploy
         run: yarn deploy
         working-directory: ./implementations/http
+        env:
+          POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD: ${{secrets.POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD}}
 
       - name: PR New URI
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/ipfs-async-uri-resolver-cd.yaml
+++ b/.github/workflows/ipfs-async-uri-resolver-cd.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Deploy
         run: yarn deploy
         working-directory: ./implementations/ipfs/async-resolver
+        env:
+          POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD: ${{secrets.POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD}}
 
       - name: PR New URI
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/ipfs-sync-uri-resolver-cd.yaml
+++ b/.github/workflows/ipfs-sync-uri-resolver-cd.yaml
@@ -40,6 +40,8 @@ jobs:
       - name: Deploy
         run: yarn deploy
         working-directory: ./implementations/ipfs/sync-resolver
+        env:
+          POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD: ${{secrets.POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD}}
 
       - name: PR New URI
         uses: peter-evans/create-pull-request@v3

--- a/implementations/wrapscan/polywrap.deploy.yaml
+++ b/implementations/wrapscan/polywrap.deploy.yaml
@@ -12,7 +12,7 @@ jobs:
         package: http
         uri: $$ipfs_deploy
         config:
-          postUrl: https://wraps.wrapscan.io/r/polywrap/wrapscan-uri-resolver@1.0.0
+          postUrl: https://wraps.wrapscan.io/r/polywrap/wrapscan-uri-resolver@1.0.1
           headers:
             - name: Authorization
               value: $POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD


### PR DESCRIPTION
ENV registration was missing from most revolver CD manifests.
wrapscan resolver is already published at 1.0.0, so I bumped the version up