### PR TITLE
Updated wrapscan to use https

### DIFF
--- a/implementations/wrapscan/URI.txt
+++ b/implementations/wrapscan/URI.txt
@@ -1,1 +1,1 @@
-wrap://http/https://wraps.wrapscan.io/r/polywrap/wrapscan-uri-resolver@1.0.1
+wrap://ipfs/QmYg55yAtGHqEpiA5nRNHu9qEdAWYWs72qgeUShUCZd3Pb

--- a/implementations/wrapscan/polywrap.deploy.yaml
+++ b/implementations/wrapscan/polywrap.deploy.yaml
@@ -12,7 +12,7 @@ jobs:
         package: http
         uri: $$ipfs_deploy
         config:
-          postUrl: https://wraps.wrapscan.io/r/polywrap/wrapscan-uri-resolver@1.0.1
+          postUrl: https://wraps.wrapscan.io/r/polywrap/wrapscan-uri-resolver@1.0.2
           headers:
             - name: Authorization
               value: $POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD

--- a/implementations/wrapscan/src/__tests__/e2e/integration.spec.ts
+++ b/implementations/wrapscan/src/__tests__/e2e/integration.spec.ts
@@ -12,8 +12,8 @@ describe("wrapscan-uri-resolver e2e tests", () => {
   const client: PolywrapClient = new PolywrapClient();
 
   const testWrapPath = "wrap/test-wrap@1.0.0";
-  const wrapscanUrl = "http/wraps.wrapscan.io";
-  const wrapscanDevUrl = "http/dev.wraps.wrapscan.io";
+  const wrapscanUrl = "https/wraps.wrapscan.io";
+  const wrapscanDevUrl = "https/dev.wraps.wrapscan.io";
   const resolvePath = "/r/";
 
   let wrapperUri: string;

--- a/implementations/wrapscan/src/lib.rs
+++ b/implementations/wrapscan/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod wrap;
 pub use wrap::*;
 
-const DEFAULT_PROVIDER_URL: &str = "http/wraps.wrapscan.io";
+const DEFAULT_PROVIDER_URL: &str = "https/wraps.wrapscan.io";
 const RESOLVE_PATH: &str = "/r/";
 const AUTHORITY: &str = "wrapscan.io";
 


### PR DESCRIPTION
If you use http in the browser, depsite the 301 redirect to https and despite the corse that's set up on http wrapscan there's a cors issue